### PR TITLE
[#86] Don't use from_fileobj because it is removed from messytables 0.8

### DIFF
--- a/dataconverters/commas.py
+++ b/dataconverters/commas.py
@@ -41,7 +41,7 @@ def parse(stream, guess_types=True, **kwargs):
     quotechar = metadata.get('quotechar', None)
     window = metadata.get('window', None)
     encoding = metadata.get('encoding', None)
-    table_set = CSVTableSet.from_fileobj(stream, delimiter=delimiter,
+    table_set = CSVTableSet(stream, delimiter=delimiter,
             quotechar=quotechar, encoding=encoding, window=window)
     strict_type_guess = metadata.get('strict_type_guess', False)
     row_set = table_set.tables.pop()

--- a/dataconverters/xls.py
+++ b/dataconverters/xls.py
@@ -29,7 +29,7 @@ def parse(stream, excel_type='xls', sheet=1, guess_types=True,
         xlsclass = XLSXTableSet
         # xlsx parser does not support encoding
         kwargs = {}
-    table_set = xlsclass.from_fileobj(stream, **kwargs)
+    table_set = xlsclass(stream, **kwargs)
     try:
         row_set = table_set.tables[sheet_number]
     except IndexError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-messytables==0.7
+messytables==0.8
 Fiona
 unicodecsv


### PR DESCRIPTION
Fixes #86 
